### PR TITLE
initdbのオプション変更

### DIFF
--- a/ex01/docker-compose.yml
+++ b/ex01/docker-compose.yml
@@ -6,7 +6,7 @@ services:
       - 127.0.0.1:5432:5432
     environment:
       POSTGRES_PASSWORD: expasswd
-      POSTGRES_INITDB_ARGS: "--no-locale -E UTF-8"
+      POSTGRES_INITDB_ARGS: "--no-locale -E UTF-8 -A scram-sha-256"
       TZ: Asia/Tokyo
     healthcheck:
       test: "pg_isready -U postgres || exit 1"

--- a/ex02/docker-compose.yml
+++ b/ex02/docker-compose.yml
@@ -6,7 +6,7 @@ services:
       - 127.0.0.1:5432:5432
     environment:
       POSTGRES_PASSWORD: expasswd
-      POSTGRES_INITDB_ARGS: "--no-locale -E UTF-8"
+      POSTGRES_INITDB_ARGS: "--no-locale -E UTF-8 -A scram-sha-256"
       TZ: Asia/Tokyo
     healthcheck:
       test: "pg_isready -U postgres || exit 1"

--- a/ex03/docker-compose.yml
+++ b/ex03/docker-compose.yml
@@ -6,7 +6,7 @@ services:
       - 127.0.0.1:5432:5432
     environment:
       POSTGRES_PASSWORD: expasswd
-      POSTGRES_INITDB_ARGS: "--no-locale -E UTF-8"
+      POSTGRES_INITDB_ARGS: "--no-locale -E UTF-8 -A scram-sha-256"
       TZ: Asia/Tokyo
     healthcheck:
       test: "pg_isready -U postgres || exit 1"

--- a/ex04/docker-compose.yml
+++ b/ex04/docker-compose.yml
@@ -6,7 +6,7 @@ services:
       - 127.0.0.1:5432:5432
     environment:
       POSTGRES_PASSWORD: expasswd
-      POSTGRES_INITDB_ARGS: "--no-locale -E UTF-8"
+      POSTGRES_INITDB_ARGS: "--no-locale -E UTF-8 -A scram-sha-256"
       TZ: Asia/Tokyo
     command: postgres -c max_prepared_transactions=1 -c log_statement=all
     healthcheck:


### PR DESCRIPTION
warning対応

```
initdb: warning: enabling "trust" authentication for local connections
initdb: hint: You can change this by editing pg_hba.conf or using the option -A, or --auth-local and --auth-host, the next time you run initdb.
```
